### PR TITLE
⚙️✚  Set and check `NODE_ENV` environment variable during test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:unit && npm run lint",
     "lint": "eslint checker lookup setgithubcheck test",
-    "test:unit": "jasmine --config=test/jasmine.json"
+    "test:unit": "cross-env NODE_ENV=test jasmine --config=test/jasmine.json"
   },
   "repository": {
     "type": "git",
@@ -29,6 +29,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
+    "cross-env": "^5.2.0",
     "eslint": "^5.11.1",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",

--- a/utils.js
+++ b/utils.js
@@ -26,7 +26,7 @@ module.exports = {
         githubKey: process.env.GITHUB_KEY,
         githubAppId: process.env.GITHUB_APP_ID
       };
-    } else if (process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_PULL_REQUEST.length) {
+    } else if (process.env.NODE_ENV === 'test' || (process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_PULL_REQUEST.length)) {
       config = {};
     } else {
       throw new Error('no config file nor environment variables exist for populating configuration');


### PR DESCRIPTION
- added cross-env as a dev dependency to set environment variables in a cross-platform friendly way.
- unit testing now sets the NODE_ENV env var to `test`.
- utils.js ignores the need for a config if the NODE_ENV var is set to "test"

This fixes #28.

Please review and test @stevengill @hirenoble - remove any/all `config.json` files you have locally and try running `npm test`. This ensures the same testing environment exists when running tests on Travis vs. locally.