### PR TITLE
✅🐛✚ [checker] now listens to pr synchronize events

### DIFF
--- a/checker/checker.js
+++ b/checker/checker.js
@@ -22,13 +22,14 @@ gets fired from github pr creation webhook.
 * if signed, give checkmark
 * if not signed, give an 'x' and tell them to go sign at http://opensource.adobe.com/cla
 */
+var valid_pr_events = ['opened', 'reopened', 'synchronize'];
 
 function main (params) {
   return new Promise(function (resolve, reject) {
-    if (!params.pull_request || (params.action !== 'opened' && params.action !== 'reopened')) {
+    if (!params.pull_request || !valid_pr_events.includes(params.action)) {
       return resolve({
         statusCode: 202,
-        body: 'Not a pull request being opened, ignoring payload'
+        body: 'Not a pull request being (re)opened or synchronized, ignoring'
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:unit && npm run lint",
     "lint": "eslint checker lookup setgithubcheck test",
-    "test:unit": "jasmine --config=test/jasmine.json"
+    "test:unit": "jasmine --config=test/jasmine.json --reporter=jasmine-console-reporter"
   },
   "repository": {
     "type": "git",
@@ -37,6 +37,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^3.3.1",
+    "jasmine-console-reporter": "^3.1.0",
     "rewire": "^4.0.1"
   }
 }


### PR DESCRIPTION
Also:

- added positive tests for listening on events to process
- tweaked test checking which pr events to ignore to include edited pr event
- added nicer jasmine console reporter for tests.

This PR fixes #21.