### PR TITLE
Full test suite and request package moved to promises

### DIFF
--- a/checker/package.json
+++ b/checker/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "github-app": "^4.0.1"
+    "github-app": "^4.0.1",
+    "request-promise-native": "^1.0.5"
   }
 }

--- a/lookup/package.json
+++ b/lookup/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "csv-parse": "^4.3.0",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "csv-parse": "^4.3.0",
     "github-app": "^4.0.1",
     "openwhisk": "^3.18.0",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.5"
   },
   "devDependencies": {
     "cross-env": "^5.2.0",

--- a/setgithubcheck/package.json
+++ b/setgithubcheck/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "github-app": "^4.0.1"
+    "github-app": "^4.0.1",
+    "request-promise-native": "^1.0.5"
   }
 }

--- a/test/checker.test.js
+++ b/test/checker.test.js
@@ -145,15 +145,15 @@ describe('checker action', function () {
         code: 404,
         message: 'hiren is not a member of the organization'
       }));
-      request_spy.and.callFake(function (options, cb) {
+      request_spy.and.callFake(function (options) {
         if (options.url.includes('agreements')) {
-          cb(null, { statusCode: 200 }, { userAgreementList: [{
+          return Promise.resolve({ userAgreementList: [{
             status: 'SIGNED',
             name: 'Adobe CLA',
             agreementId: '123'
           }] });
         } else {
-          cb(null, { statusCode: 200 }, '{"access_token":"yes"}');
+          return Promise.resolve({ 'access_token': 'yes' });
         }
       });
       openwhisk_stub.actions.invoke.and.callFake(function (params) {
@@ -196,15 +196,15 @@ describe('checker action', function () {
         code: 404,
         message: 'hiren is not a member of the organization'
       }));
-      request_spy.and.callFake(function (options, cb) {
+      request_spy.and.callFake(function (options) {
         if (options.url.includes('agreements')) {
-          cb(null, { statusCode: 200 }, { userAgreementList: [{
+          return Promise.resolve({ userAgreementList: [{
             status: 'SIGNED',
             name: 'Adobe CLA',
             agreementId: '123'
           }] });
         } else {
-          cb(null, { statusCode: 200 }, '{"access_token":"yes"}');
+          return Promise.resolve({ 'access_token': 'yes' });
         }
       });
       openwhisk_stub.actions.invoke.and.callFake(function (params) {
@@ -247,11 +247,11 @@ describe('checker action', function () {
         code: 404,
         message: 'hiren is not a member of the organization'
       }));
-      request_spy.and.callFake(function (options, cb) {
+      request_spy.and.callFake(function (options) {
         if (options.url.includes('agreements')) {
-          cb(null, { statusCode: 200 }, { userAgreementList: [] });
+          return Promise.resolve({ userAgreementList: [] });
         } else {
-          cb(null, { statusCode: 200 }, '{"access_token":"yes"}');
+          return Promise.resolve({ 'access_token': 'yes' });
         }
       });
       openwhisk_stub.actions.invoke.and.returnValue(Promise.resolve({}));

--- a/test/lookup.test.js
+++ b/test/lookup.test.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+var rewire = require('rewire');
+var lookup = rewire('../lookup/lookup.js');
+
+describe('lookup action', function () {
+  describe('failure', function () {
+    it('should reject if parameters do not contain agreements', function (done) {
+      lookup.main({}).then(function () {
+        fail('unexpected promise resolution');
+      }).catch(function () {
+        done();
+      });
+    });
+  });
+  describe('happy path', function () {
+    var revert_request_mock, request_spy; // stubbing request module
+    var revert_parse_mock, parse_spy; // stubbing csv-parse module
+    beforeEach(function () {
+      request_spy = jasmine.createSpy('request spy').and.callFake(function (options) {
+        if (options.url.includes('oauth/refresh')) {
+          return Promise.resolve({ access_token: 'yes' });
+        } else {
+          return Promise.resolve('this will not be used');
+        }
+      });
+      revert_request_mock = lookup.__set__('request', request_spy);
+      parse_spy = jasmine.createSpy('parse spy').and.callFake(function (body, opts, cb) {
+        cb(null, [{ githubUsername: 'steve' }]);
+      });
+      revert_parse_mock = lookup.__set__('parse', parse_spy);
+    });
+    afterEach(function () {
+      revert_request_mock();
+      revert_parse_mock();
+    });
+    it('should be able to handle a single agreement', function (done) {
+      var params = {
+        agreements: '12345'
+      };
+      lookup.main(params).then(function (result) {
+        expect(result.body.usernames).toContain('steve');
+        done();
+      }).catch(function (err) {
+        fail(err);
+      });
+    });
+    it('should be able to handle multiple agreements', function (done) {
+      parse_spy.and.callFake(function (body, opts, cb) {
+        cb(null, [{ githubUsername: 'steve' + Math.random() }]);
+      });
+      var params = {
+        agreements: ['12345', '43561']
+      };
+      lookup.main(params).then(function (result) {
+        expect(result.body.usernames.length).toBe(2);
+        done();
+      }).catch(function (err) {
+        fail(err);
+      });
+    });
+  });
+});

--- a/test/setgithubcheck.test.js
+++ b/test/setgithubcheck.test.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+var rewire = require('rewire');
+var setgithubcheck = rewire('../setgithubcheck/setgithubcheck.js');
+
+describe('setgithubcheck action', function () {
+  var revert_github_app_mock, app_spy, github_api_stub; // stubbing github app / api calls
+  beforeEach(function () {
+    github_api_stub = {
+      checks: {
+        create: jasmine.createSpy('create check spy')
+      }
+    };
+    app_spy = jasmine.createSpy('github app spy').and.returnValue({
+      asInstallation: jasmine.createSpy('GitHub App asInstallation spy').and.returnValue(Promise.resolve(github_api_stub))
+    });
+    revert_github_app_mock = setgithubcheck.__set__('github_app', app_spy);
+  });
+  afterEach(function () {
+    revert_github_app_mock();
+  });
+  it('should fail if creating a check fails', function (done) {
+    github_api_stub.checks.create.and.returnValue(Promise.reject(new Error('boom!')));
+    setgithubcheck.main({}).then(function () {
+      fail('unexpected promise resolution');
+    }).catch(function (err) {
+      expect(err.message).toContain('boom!');
+      done();
+    });
+  });
+  it('should return title parameter if check passes', function (done) {
+    github_api_stub.checks.create.and.returnValue(Promise.resolve({}));
+    setgithubcheck.main({ title: 'batman' }).then(function (result) {
+      expect(result.title).toBe('batman');
+      done();
+    }).catch(function (err) {
+      fail(err);
+    });
+  });
+});


### PR DESCRIPTION
DO NOT MERGE! Please only review.

- Added tests for lookup and setgithubcheck actions
- Moved checker and lookup actions from oldschool request callback style to promises

This closes #33.

Assuming this passes review, I think we should do a manual deploy from this branch, then run through @hirenoble's live (github.com) tests to see if things still work. It's a relatively large changeset that could contain a bit of risk. If it fails, we swap out to master branch and redeploy to production quickly. If everything is OK, we can merge the PR in.