### PR TITLE
doc: link to cla-bot in action_required message

### DIFF
--- a/checker/checker.js
+++ b/checker/checker.js
@@ -330,7 +330,14 @@ async function action_required (ow, args) {
         conclusion: 'action_required',
         details_url: 'https://opensource.adobe.com/cla.html',
         title: 'Sign the Adobe CLA!',
-        summary: 'No signed agreements were found. Please [sign the Adobe CLA](http://opensource.adobe.com/cla.html)! Once signed, close and re-open your pull request to run the check again.\n\n If you are an Adobe employee, you do not have to sign the CLA. Instead [add yourself to the Adobe GitHub Org](https://git.corp.adobe.com/OpenSourceAdvisoryBoard/handbook/blob/master/GitHub-Adobe-Org-Management.md#request-access-to-our-adobe-github-org) to be recognized as an Adobe Employee. Once added to the GitHub Org, close and re-open the pull-request to run the check again.\n\n If you have any questions, contact Adobe\'s Open Source Office by mentioning them on the pull request with **@adobe/open-source-office** or via email <grp-opensourceoffice@adobe.com>.'
+        summary: `
+No signed agreements were found. Please [sign the Adobe CLA](http://opensource.adobe.com/cla.html)! Once signed, close and re-open your pull request to run the check again.
+
+If you are an Adobe employee, you do not have to sign the CLA. Instead [add yourself to the Adobe GitHub Org](https://git.corp.adobe.com/OpenSourceAdvisoryBoard/handbook/blob/master/GitHub-Adobe-Org-Management.md#request-access-to-our-adobe-github-org) to be recognized as an Adobe Employee. Once added to the GitHub Org, close and re-open the pull-request to run the check again.
+
+If you have any questions, contact Adobe\'s Open Source Office by mentioning them on the pull request with **@adobe/open-source-office** or via email <grp-opensourceoffice@adobe.com>.
+
+If you believe this was a mistake, please report an issue at [adobe/cla-bot](https://github.com/adobe/cla-bot/issues).`
       }
     });
   } catch (e) {

--- a/checker/checker.js
+++ b/checker/checker.js
@@ -335,7 +335,7 @@ No signed agreements were found. Please [sign the Adobe CLA](http://opensource.a
 
 If you are an Adobe employee, you do not have to sign the CLA. Instead [add yourself to the Adobe GitHub Org](https://git.corp.adobe.com/OpenSourceAdvisoryBoard/handbook/blob/master/GitHub-Adobe-Org-Management.md#request-access-to-our-adobe-github-org) to be recognized as an Adobe Employee. Once added to the GitHub Org, close and re-open the pull-request to run the check again.
 
-If you have any questions, contact Adobe\'s Open Source Office by mentioning them on the pull request with **@adobe/open-source-office** or via email <grp-opensourceoffice@adobe.com>.
+If you have any questions, contact Adobe's Open Source Office by mentioning them on the pull request with **@adobe/open-source-office** or via email <grp-opensourceoffice@adobe.com>.
 
 If you believe this was a mistake, please report an issue at [adobe/cla-bot](https://github.com/adobe/cla-bot/issues).`
       }


### PR DESCRIPTION
Closes https://github.com/adobe/cla-bot/issues/47

Adds a link to the cla-bot issues page in the action required message when a CLA check fails.