### PR TITLE
Deploy.sh and integration tests cannot be run from a pull request.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
 script:
   - npm run lint
   - npm run test:unit
-  - bash deploy.sh lookup && bash deploy.sh setgithubcheck && bash deploy.sh checker && bash deploy.sh signwebhook
-  - npm run test:integration
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash deploy.sh lookup && bash deploy.sh setgithubcheck && bash deploy.sh checker && bash deploy.sh signwebhook; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:integration; fi
 deploy:
   provider: script
   script: bash deploy.sh lookup production && bash deploy.sh setgithubcheck production && bash deploy.sh checker production && bash deploy.sh signwebhook production


### PR DESCRIPTION
This PR adds some checks to make sure that some parts of the script are not called when the build is started from a pull request.