### PR TITLE
DEVX-311: Update Adobe CLA bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ This repo contains three actions, which are functions that run on a serverless
 - [`./checker`][checker] contains an action that runs on every [github.com/adobe]
   pull request open, close and synchronize. Checker's job is to check if the user
   submitting the pull request has signed the [CLA][cla] or if the user is an Adobe or
-  Magento employee (by checking [github.com/adobe] or magento organization membership).
+  Magento employee (by checking [github.com/adobe] or [github.com/magento-commerce]
+  organizations membership).
 - [`./setgithubcheck`][setgithubcheck] contains an action that interacts with the
   GitHub REST API's [Checks API](https://developer.github.com/v3/checks/runs) to
   set checkmarks on pull requests. It is invoked by other actions to communicate

--- a/test/integration/github.test.js
+++ b/test/integration/github.test.js
@@ -134,7 +134,7 @@ describe('github integration tests', () => {
       await teardown();
     });
   });
-  describe('pull requests from user who is a member of the adobe or magento orgs (and magento-employees team) (account adobeiotest4)', () => {
+  describe('pull requests from user who is a member of the adobe or magento-commerce orgs (account adobeiotest4)', () => {
     const user = 'adobeiotest4';
     const newBranch = '' + new Date().valueOf();
     const github = new Octokit({

--- a/test/integration/github.test.js
+++ b/test/integration/github.test.js
@@ -24,7 +24,7 @@ if (!process.env.TEST_MAJ583_PAC) throw new Error('environment variable `TEST_MA
  * - TEST_TWO_PAC: PAC for account adobeiotest2. Adobe CCLA signed. not a member
  *   of any orgs.
  * - TEST_FOUR_PAC: PAC for account adobeiotest4. Adobe CCLA signed. member of
- *   the adobe org and magento org (and part of magento-employees team).
+ *   the adobe org and magento-commerce org.
  * - TEST_MAJ_PAC: PAC for account majtest. no CLA signed. not a member of any
  *   orgs. added as a _collaborator_ on magento/devops-cla-test and
  *   magento/devops-cla-test-adcb

--- a/test/unit/checker.test.js
+++ b/test/unit/checker.test.js
@@ -44,9 +44,6 @@ describe('checker action', function () {
         orgs: {
           checkMembership: jasmine.createSpy('orgs.checkMembership spy'),
           checkPublicMembership: jasmine.createSpy('orgs.checkPublicMembership spy')
-        },
-        teams: {
-          getMembership: jasmine.createSpy('team.getMembership spy')
         }
       };
       app_spy = jasmine.createSpy('github app spy').and.returnValue({
@@ -134,7 +131,7 @@ describe('checker action', function () {
           action: 'opened',
           installation: { id: '5431' }
         };
-        github_api_stub.teams.getMembership.and.returnValue(Promise.resolve({
+        github_api_stub.orgs.checkMembership.and.returnValue(Promise.resolve({
           status: 204
         }));
         openwhisk_stub.actions.invoke.and.returnValue(Promise.resolve({}));
@@ -160,8 +157,9 @@ describe('checker action', function () {
           action: 'opened',
           installation: { id: '5431' }
         };
-        github_api_stub.teams.getMembership.and.returnValue(Promise.reject({
-          message: 'Not Found'
+        github_api_stub.orgs.checkMembership.and.returnValue(Promise.reject({
+          code: 404,
+          message: 'hiren is not a member of the organization'
         }));
         request_spy.and.callFake(function (options) {
           if (options.url.includes('agreements')) {
@@ -210,8 +208,9 @@ describe('checker action', function () {
           action: 'opened',
           installation: { id: '5431' }
         };
-        github_api_stub.teams.getMembership.and.returnValue(Promise.reject({
-          message: 'Not Found'
+        github_api_stub.orgs.checkMembership.and.returnValue(Promise.reject({
+          code: 404,
+          message: 'hiren is not a member of the organization'
         }));
         request_spy.and.callFake(function (options) {
           if (options.url.includes('agreements')) {
@@ -260,8 +259,9 @@ describe('checker action', function () {
           action: 'opened',
           installation: { id: '5431' }
         };
-        github_api_stub.teams.getMembership.and.returnValue(Promise.reject({
-          message: 'Not Found'
+        github_api_stub.orgs.checkMembership.and.returnValue(Promise.reject({
+          code: 404,
+          message: 'hiren is not a member of the organization'
         }));
         request_spy.and.callFake(function (options) {
           if (options.url.includes('agreements')) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the PR title above -->

# Description
This PR changes the logic of Magento employee identification. Now it is `magento-commerce` org instead of `magento-employee` team.
<!--- Describe your changes in detail -->

# Checklist

- [ ] Read [Contribution guidelines](https://github.com/adobe/cla-bot/blob/master/.github/CONTRIBUTING.md)
- [ ] Added tests for new features or bugfixes

# Related Issue
<!--- Please link to the related issue -->
[DEVX-311](https://jira.corp.adobe.com/browse/DEVX-311): Update Adobe CLA bot
<!--- If this PR closes the issue, then type `Closes #XXX` to auto-close the issue once this PR is merged -->
