### PR TITLE
Enable merge queue

### DIFF
--- a/checker/checker.js
+++ b/checker/checker.js
@@ -27,8 +27,12 @@ const valid_pr_events = ['opened', 'reopened', 'synchronize'];
 const valid_merge_group_events = ['checks_requested'];
 
 async function main (params) {
-  // we should be falling in to the 202 ignore case for merge_group events because they don't have params.pull_request
-  // possibly 202 isn't good enough for a required check though?
+  // technically, we shouldn't even need to check this here, as anything without a
+  // pull_request property should have been filtered out by the webhook
+  // which means that a merge_queue should already pass, the only reason we have been
+  // failing so far I believe is because we were not getting the event at all, so couldn't
+  // mark it as passing. On the chance I'm wrong, I'm leaving this here for now.
+  // but we may not even need a code change
   console.log('params: ', params);
   if (valid_merge_group_events.includes(params.action)) {
     return {

--- a/checker/checker.js
+++ b/checker/checker.js
@@ -22,7 +22,7 @@ gets fired from github pr creation/update webhook.
 * if signed, give checkmark
 * if not signed, give an 'x' and tell them to go sign at https://opensource.adobe.com/cla.html
 */
-const valid_pr_events = ['opened', 'reopened', 'synchronize'];
+const valid_pr_events = ['opened', 'reopened', 'synchronize', 'checks_requested'];
 
 async function main (params) {
   if (!params.pull_request || !valid_pr_events.includes(params.action)) {
@@ -49,7 +49,9 @@ async function main (params) {
     user: user
   };
 
-  if (params.pull_request.user.type === 'Bot') {
+  // better to check the action? or the user type? it should also be bot, but I
+  // haven't been successful in seeing a merge_group checks_requested event yet in my own testing.
+  if (params.pull_request.user.type === 'Bot' || params.action === 'checks_requested') {
     const res = await set_green_is_bot(ow, args);
     return res;
   }

--- a/checker/checker.js
+++ b/checker/checker.js
@@ -25,6 +25,10 @@ gets fired from github pr creation/update webhook.
 const valid_pr_events = ['opened', 'reopened', 'synchronize', 'checks_requested'];
 
 async function main (params) {
+  // it was suggested that we need to check for params.merge_group here, but
+  // it doesn't appear to be in the types, so I'll log it out and check in a run
+  // in the integration tests once we get the right branch in place
+  console.log(params);
   if (!params.pull_request || !valid_pr_events.includes(params.action)) {
     return {
       statusCode: 202,

--- a/test/integration/github.test.js
+++ b/test/integration/github.test.js
@@ -266,7 +266,7 @@ describe('github integration tests', () => {
         repo: ADOBE_REPO,
         title: `testing build ${newBranch}`,
         head: `${user}:${newBranch}`,
-        base: 'mergeq' // need to create this branch and give it merge_queue protections
+        base: 'mergeq'
       });
       const suite = await waitForCheck(github, 'adobe', ADOBE_REPO, pr.data.head.sha);
       expect(suite.conclusion).toEqual('success');

--- a/test/unit/checker.test.js
+++ b/test/unit/checker.test.js
@@ -93,25 +93,14 @@ describe('checker action', function () {
       }));
     });
     it('should pass merge queue commits', async function () {
-      github_api_stub.orgs.checkMembership.and.returnValue(Promise.resolve({
-        status: 204
-      }));
       openwhisk_stub.actions.invoke.and.returnValue(Promise.resolve({}));
       const events = ['checks_requested'];
       const params = events.map(function (event) {
         return {
-          pull_request: {
-            user: { login: 'hiren' },
-            base: {
-              repo: {
-                owner: { login: 'adobe' },
-                name: 'photoshop'
-              }
-            },
-            head: { sha: '12345' }
-          },
           action: event,
-          installation: { id: '5431' }
+          merge_group: {
+            head_sha: 'madeuphash'
+          }
         };
       });
       await Promise.all(params.map(async function (param) {

--- a/test/unit/checker.test.js
+++ b/test/unit/checker.test.js
@@ -92,6 +92,33 @@ describe('checker action', function () {
         expect(result.statusCode).toBe(200);
       }));
     });
+    it('should pass merge queue commits', async function () {
+      github_api_stub.orgs.checkMembership.and.returnValue(Promise.resolve({
+        status: 204
+      }));
+      openwhisk_stub.actions.invoke.and.returnValue(Promise.resolve({}));
+      const events = ['checks_requested'];
+      const params = events.map(function (event) {
+        return {
+          pull_request: {
+            user: { login: 'hiren' },
+            base: {
+              repo: {
+                owner: { login: 'adobe' },
+                name: 'photoshop'
+              }
+            },
+            head: { sha: '12345' }
+          },
+          action: event,
+          installation: { id: '5431' }
+        };
+      });
+      await Promise.all(params.map(async function (param) {
+        const result = await checker.main(param);
+        expect(result.statusCode).toBe(200);
+      }));
+    });
     it('should invoke the setgithubcheck action with a status of completed if user is a bot', async function () {
       const params = {
         pull_request: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the PR title above -->

# Description
<!--- Describe your changes in detail -->

Work in progress.
I need a branch added to the staging cla-bot-playground repo which is protected by a merge queue. The events should already be turned on in there.

# Checklist

- [x] Read [Contribution guidelines](https://github.com/adobe/cla-bot/blob/master/.github/CONTRIBUTING.md)
- [x] Added tests for new features or bugfixes

# Related Issue
<!--- Please link to the related issue -->
<!--- If this PR closes the issue, then type `Closes #XXX` to auto-close the issue once this PR is merged -->
Closes https://github.com/adobe/cla-bot/issues/157